### PR TITLE
Disallow robots from eliding lock

### DIFF
--- a/lib/capistrano/deploy_lock/version.rb
+++ b/lib/capistrano/deploy_lock/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module DeployLock
-    VERSION = '2.0.0'
+    VERSION = '2.1.0'
   end
 end

--- a/lib/capistrano/tasks/deploy_lock.rake
+++ b/lib/capistrano/tasks/deploy_lock.rake
@@ -136,7 +136,7 @@ namespace :deploy_lock do
 
       # Don't raise exception if current user owns the lock, and lock has an expiry time.
       # Just sleep for a few seconds so they have a chance to cancel the deploy with Ctrl-C
-      if deploy_lock[:expire_at] && deploy_lock[:username] == ENV['USER']
+      if deploy_lock[:expire_at] && deploy_lock[:username] == ENV['USER'] && ENV['USER'] != ENV['AUTOMATED_DEPLOY_USER']
         5.downto(1) do |i|
           Kernel.print "\rDeploy lock was created by you (#{ENV['USER']}). Continuing deploy in #{i}..."
           sleep 1


### PR DESCRIPTION
Only actual humans should be able to do this. It is on us to setup our
deploy machines with the proper environment variable to keep this from
happening.